### PR TITLE
feat: configurable global and per-hook command timeouts

### DIFF
--- a/src/hookshot/__main__.py
+++ b/src/hookshot/__main__.py
@@ -225,7 +225,15 @@ def cmd_test(args):
     state = StateStore(config.get("state_file"))
     hooks = config.get("hooks", {})
     worktrees = config.get("worktrees")
-    executed = match_and_run(hooks, event, payload, dry_run=True, state=state, worktrees=worktrees)
+    executed = match_and_run(
+        hooks,
+        event,
+        payload,
+        dry_run=True,
+        state=state,
+        worktrees=worktrees,
+        default_timeout=config.get("timeout"),
+    )
     print(f"\nMatched and would execute {executed} command(s)")
 
 

--- a/src/hookshot/config.py
+++ b/src/hookshot/config.py
@@ -16,6 +16,14 @@ LOCAL_CONFIG_PATH = Path("hookshot.yml")
 DEFAULT_CONFIG_PATH = _CONFIG_DIR / "hooks.yml"
 DEFAULT_STATE_PATH = _DATA_DIR / "state.json"
 
+# Fallback when neither global nor per-command timeout is set (seconds)
+DEFAULT_COMMAND_TIMEOUT = 300
+
+
+def _is_positive_int(value: object) -> bool:
+    """True if value is a positive integer (not bool)."""
+    return type(value) is int and value > 0
+
 
 def expand_env(value: str) -> str:
     """Expand ${ENV_VAR} references in a string."""
@@ -110,6 +118,10 @@ def validate_config(config: dict) -> list[str]:
     if repo and not re.match(r"^[\w.-]+/[\w.-]+$", repo):
         errors.append(f"'repo' must be in owner/name format, got '{repo}'")
 
+    if "timeout" in config and config["timeout"] is not None:
+        if not _is_positive_int(config["timeout"]):
+            errors.append("'timeout' must be a positive integer (seconds)")
+
     hooks = config.get("hooks", {})
     if not isinstance(hooks, dict):
         errors.append("'hooks' must be a mapping of event names to command lists")
@@ -125,6 +137,12 @@ def validate_config(config: dict) -> list[str]:
                 continue
             if "command" not in cmd:
                 errors.append(f"hooks.{event}[{i}]: missing 'command' key")
+
+            if "timeout" in cmd:
+                if not _is_positive_int(cmd["timeout"]):
+                    errors.append(
+                        f"hooks.{event}[{i}].timeout: must be a positive integer (seconds)"
+                    )
 
             # Validate store directive
             if "store" in cmd:

--- a/src/hookshot/matcher.py
+++ b/src/hookshot/matcher.py
@@ -79,6 +79,7 @@ def match_and_run(
     state: StateStore | None = None,
     reactions: dict | None = None,
     worktrees: dict | None = None,
+    default_timeout: int | None = None,
 ) -> int:
     """Match a GitHub event against configured hooks and run matching commands.
 
@@ -88,6 +89,9 @@ def match_and_run(
     - "pull_request" matches X-GitHub-Event: pull_request with ANY action
 
     Returns the number of commands executed.
+
+    default_timeout: global command timeout in seconds from config (``timeout``).
+        Per-hook ``timeout`` overrides this; if both are unset, 300s is used.
     """
     action = payload.get("action", "")
     qualified = f"{event}.{action}" if action else None
@@ -110,7 +114,15 @@ def match_and_run(
                     log.error("  Skipping command %d/%d (worktree creation failed): %s", i, len(commands), cmd.get("command", "?"))
                     continue
                 log.info("  Running command %d/%d: %s", i, len(commands), cmd.get("command", "?"))
-                if run_command(cmd, payload, dry_run=dry_run, state=state, reactions=reactions, cwd=cwd):
+                if run_command(
+                    cmd,
+                    payload,
+                    dry_run=dry_run,
+                    state=state,
+                    reactions=reactions,
+                    cwd=cwd,
+                    default_timeout=default_timeout,
+                ):
                     executed += 1
 
     # Handle worktree cleanup on issue close (after commands run)

--- a/src/hookshot/runner.py
+++ b/src/hookshot/runner.py
@@ -7,6 +7,7 @@ import re
 import subprocess
 from typing import TYPE_CHECKING
 
+from .config import DEFAULT_COMMAND_TIMEOUT
 from .reactions import add_reaction, remove_reaction
 
 if TYPE_CHECKING:
@@ -102,6 +103,15 @@ def expand_template(
     return re.sub(r"\$\{\{\s*([^}]+?)\s*\}\}", replacer, template)
 
 
+def resolve_command_timeout(cmd_config: dict, default_timeout: int | None) -> int:
+    """Per-command timeout overrides global default; else fallback seconds."""
+    if "timeout" in cmd_config:
+        return cmd_config["timeout"]
+    if default_timeout is not None:
+        return default_timeout
+    return DEFAULT_COMMAND_TIMEOUT
+
+
 def is_truthy(value: str) -> bool:
     """Evaluate a string for truthiness after template expansion.
 
@@ -119,10 +129,14 @@ def run_command(
     state: StateStore | None = None,
     reactions: dict | None = None,
     cwd: str | None = None,
+    default_timeout: int | None = None,
 ) -> bool:
     """Expand templates in a command config and execute it.
 
     Returns True if the command ran (or would run in dry_run mode).
+
+    default_timeout: seconds when the command has no ``timeout`` key (from global
+        config). Falls back to :data:`hookshot.config.DEFAULT_COMMAND_TIMEOUT`.
     """
     # Load state context
     state_context = None
@@ -149,10 +163,13 @@ def run_command(
                 log.info("  Skipped (condition false: %s): %s", cond, command)
                 return False
 
+    timeout_sec = resolve_command_timeout(cmd_config, default_timeout)
+
     if dry_run:
         log.info("  [dry-run] Would execute: %s", command)
         if cwd:
             log.info("  [dry-run] cwd: %s", cwd)
+        log.info("  [dry-run] timeout: %ds", timeout_sec)
         if stdin_text:
             log.info("  [dry-run] stdin: %s", stdin_text[:200])
         _process_store(cmd_config, payload, state, state_context, dry_run=True)
@@ -174,7 +191,7 @@ def run_command(
             shell=True,
             capture_output=True,
             text=True,
-            timeout=300,
+            timeout=timeout_sec,
             input=stdin_text,
             cwd=cwd,
         )
@@ -203,7 +220,7 @@ def run_command(
         _finish_reactions(payload, reactions, success=True)
         return True
     except subprocess.TimeoutExpired:
-        log.error("  Command timed out after 300s: %s", command)
+        log.error("  Command timed out after %ds: %s", timeout_sec, command)
         _finish_reactions(payload, reactions, success=False)
         return False
     except Exception as e:

--- a/src/hookshot/server.py
+++ b/src/hookshot/server.py
@@ -63,7 +63,16 @@ class WebhookHandler(BaseHTTPRequestHandler):
         hooks = self.server.hookshot_config.get("hooks", {})
         reactions = self.server.hookshot_config.get("reactions")
         worktrees = self.server.hookshot_config.get("worktrees")
-        executed = match_and_run(hooks, event, payload, state=self.server.hookshot_state, reactions=reactions, worktrees=worktrees)
+        default_timeout = self.server.hookshot_config.get("timeout")
+        executed = match_and_run(
+            hooks,
+            event,
+            payload,
+            state=self.server.hookshot_state,
+            reactions=reactions,
+            worktrees=worktrees,
+            default_timeout=default_timeout,
+        )
 
         self.send_response(200)
         self.end_headers()

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -68,3 +68,11 @@ def test_multiple_commands_all_run(mock_run):
     count = match_and_run(hooks, "issues", payload)
     assert count == 2
     assert mock_run.call_count == 2
+
+
+@patch("hookshot.matcher.run_command", return_value=True)
+def test_match_and_run_passes_default_timeout(mock_run):
+    hooks = {"push": [{"command": "echo x"}]}
+    match_and_run(hooks, "push", {}, default_timeout=900)
+    mock_run.assert_called_once()
+    assert mock_run.call_args.kwargs.get("default_timeout") == 900

--- a/tests/test_reactions.py
+++ b/tests/test_reactions.py
@@ -7,7 +7,7 @@ from hookshot.reactions import (
     add_reaction,
     remove_reaction,
 )
-from hookshot.runner import run_command, _finish_reactions
+from hookshot.runner import run_command, _finish_reactions, resolve_command_timeout
 from hookshot.config import validate_config
 
 
@@ -244,3 +244,67 @@ def test_validate_reactions_not_a_dict():
 def test_validate_no_reactions_is_valid():
     config = {"hooks": {}}
     assert validate_config(config) == []
+
+
+# --- validate_config timeout ---
+
+def test_validate_timeout_global_valid():
+    assert validate_config({"hooks": {}, "timeout": 600}) == []
+
+
+def test_validate_timeout_global_invalid():
+    errors = validate_config({"hooks": {}, "timeout": -1})
+    assert any("timeout" in e and "positive integer" in e for e in errors)
+
+
+def test_validate_timeout_global_not_bool():
+    errors = validate_config({"hooks": {}, "timeout": True})
+    assert any("timeout" in e for e in errors)
+
+
+def test_validate_timeout_per_command_invalid():
+    errors = validate_config({
+        "hooks": {"push": [{"command": "echo", "timeout": 0}]},
+    })
+    assert any("timeout" in e and "positive integer" in e for e in errors)
+
+
+def test_validate_timeout_per_command_valid():
+    assert validate_config({
+        "hooks": {"push": [{"command": "echo", "timeout": 1800}]},
+    }) == []
+
+
+# --- resolve_command_timeout ---
+
+def test_resolve_command_timeout_precedence():
+    assert resolve_command_timeout({}, None) == 300
+    assert resolve_command_timeout({}, 600) == 600
+    assert resolve_command_timeout({"timeout": 1800}, 600) == 1800
+
+
+# --- run_command timeout ---
+
+@patch("hookshot.runner.subprocess.run")
+def test_run_command_default_timeout_300(mock_subprocess):
+    mock_subprocess.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    run_command({"command": "echo hi"}, {})
+    assert mock_subprocess.call_args.kwargs["timeout"] == 300
+
+
+@patch("hookshot.runner.subprocess.run")
+def test_run_command_respects_global_default_timeout(mock_subprocess):
+    mock_subprocess.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    run_command({"command": "echo hi"}, {}, default_timeout=600)
+    assert mock_subprocess.call_args.kwargs["timeout"] == 600
+
+
+@patch("hookshot.runner.subprocess.run")
+def test_run_command_per_hook_timeout_overrides_global(mock_subprocess):
+    mock_subprocess.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    run_command(
+        {"command": "echo hi", "timeout": 1800},
+        {},
+        default_timeout=600,
+    )
+    assert mock_subprocess.call_args.kwargs["timeout"] == 1800


### PR DESCRIPTION
Closes #10

## Summary

Adds optional top-level `timeout` (seconds) and per-hook `timeout` on each command mapping. Per-command wins over global; if neither is set, behavior matches the previous hardcoded 300s default. `validate_config` rejects non–positive-integer values for both levels.

## Verification

Run `hookshot validate` with a config that sets `timeout: 600` and a hook with `timeout: 1800`; run the test suite (`pytest`) — all tests pass including new cases for resolution order and subprocess timeout.

Made with [Cursor](https://cursor.com)