### PR TITLE
feat: background webhook processing (thread pool + 202)

### DIFF
--- a/src/hookshot/server.py
+++ b/src/hookshot/server.py
@@ -2,12 +2,14 @@
 
 import hashlib
 import hmac
+import itertools
 import json
 import logging
 import shutil
 import subprocess
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
 from .config import get_events
@@ -15,6 +17,9 @@ from .matcher import match_and_run
 from .state import StateStore
 
 log = logging.getLogger("hookshot")
+
+# Max concurrent webhook command runs (each delivery still parses/verifies synchronously)
+_DEFAULT_WORKER_THREADS = 8
 
 
 class WebhookHandler(BaseHTTPRequestHandler):
@@ -60,23 +65,38 @@ class WebhookHandler(BaseHTTPRequestHandler):
             self.wfile.write(b"Invalid JSON")
             return
 
+        delivery = self.headers.get("X-GitHub-Delivery", "-")
+        work_id = next(self.server.hookshot_work_seq)
+
         hooks = self.server.hookshot_config.get("hooks", {})
         reactions = self.server.hookshot_config.get("reactions")
         worktrees = self.server.hookshot_config.get("worktrees")
         default_timeout = self.server.hookshot_config.get("timeout")
-        executed = match_and_run(
-            hooks,
+
+        self.server.hookshot_executor.submit(
+            _run_webhook_commands,
+            self.server,
+            work_id,
+            delivery,
             event,
             payload,
-            state=self.server.hookshot_state,
-            reactions=reactions,
-            worktrees=worktrees,
-            default_timeout=default_timeout,
+            hooks,
+            reactions,
+            worktrees,
+            default_timeout,
         )
 
-        self.send_response(200)
+        log.info(
+            "Accepted webhook work_id=%s delivery=%s event=%s (queued)",
+            work_id,
+            delivery,
+            event,
+        )
+        self.send_response(202)
         self.end_headers()
-        self.wfile.write(f"Executed {executed} command(s)".encode())
+        self.wfile.write(
+            f"Accepted — work {work_id} queued (delivery {delivery})".encode()
+        )
 
     def do_GET(self):
         """Health check endpoint."""
@@ -87,6 +107,70 @@ class WebhookHandler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):
         """Route HTTP server logs through our logger."""
         log.debug(format, *args)
+
+
+def _run_webhook_commands(
+    server,
+    work_id: int,
+    delivery: str,
+    event: str,
+    payload: dict,
+    hooks: dict,
+    reactions: dict | None,
+    worktrees: dict | None,
+    default_timeout: int | None,
+) -> None:
+    """Run hook commands in a thread pool worker (HTTP handler returns before this)."""
+    threading.current_thread().name = f"hookshot-{work_id}"
+    log.info(
+        "Webhook work started work_id=%s delivery=%s event=%s thread=%s",
+        work_id,
+        delivery,
+        event,
+        threading.current_thread().name,
+    )
+    try:
+        executed = match_and_run(
+            hooks,
+            event,
+            payload,
+            state=server.hookshot_state,
+            reactions=reactions,
+            worktrees=worktrees,
+            default_timeout=default_timeout,
+        )
+        log.info(
+            "Webhook work finished work_id=%s delivery=%s executed=%d",
+            work_id,
+            delivery,
+            executed,
+        )
+    except Exception:
+        log.exception(
+            "Webhook work failed work_id=%s delivery=%s event=%s",
+            work_id,
+            delivery,
+            event,
+        )
+
+
+class HookshotHTTPServer(HTTPServer):
+    """HTTP server with a bounded pool for running webhook commands in the background."""
+
+    def __init__(
+        self,
+        server_address,
+        RequestHandlerClass,
+        *,
+        max_workers: int = _DEFAULT_WORKER_THREADS,
+        bind_and_activate: bool = True,
+    ):
+        super().__init__(server_address, RequestHandlerClass, bind_and_activate)
+        self.hookshot_work_seq = itertools.count(1)
+        self.hookshot_executor = ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix="hookshot",
+        )
 
 
 def verify_signature(body: bytes, secret: str, signature: str) -> bool:
@@ -107,7 +191,7 @@ def serve(config: dict):
     port = config["listen"]["port"]
     repo = config.get("repo")
 
-    server = HTTPServer((host, port), WebhookHandler)
+    server = HookshotHTTPServer((host, port), WebhookHandler)
     server.hookshot_config = config
     server.hookshot_state = StateStore(config.get("state_file"))
 
@@ -127,6 +211,8 @@ def serve(config: dict):
     finally:
         if gh_supervisor:
             gh_supervisor.stop()
+        log.info("Stopping command executor (waiting for in-flight webhooks)...")
+        server.hookshot_executor.shutdown(wait=True)
         server.server_close()
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,123 @@
+"""Tests for webhook server background processing."""
+
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+from hookshot.server import HookshotHTTPServer, WebhookHandler, _run_webhook_commands
+
+
+def _make_handler(headers: dict, body: bytes):
+    """Build a WebhookHandler without running the real HTTP stack."""
+    server = MagicMock(spec=HookshotHTTPServer)
+    server.hookshot_config = {
+        "hooks": {"issues": [{"command": "echo x"}]},
+        "reactions": None,
+        "worktrees": None,
+        "timeout": None,
+    }
+    server.hookshot_state = MagicMock()
+    server.hookshot_work_seq = iter(range(1, 1000))
+    server.hookshot_executor = MagicMock()
+
+    handler = WebhookHandler.__new__(WebhookHandler)
+    handler.server = server
+    handler.client_address = ("127.0.0.1", 12345)
+    handler.rfile = BytesIO(body)
+    handler.wfile = BytesIO()
+    handler.headers = headers
+
+    def _send_response_only(code, message=None):
+        handler._response_code = code
+
+    def _send_header(k, v):
+        pass
+
+    def _end_headers():
+        pass
+
+    handler.send_response = _send_response_only
+    handler.send_header = _send_header
+    handler.end_headers = _end_headers
+
+    return handler, server
+
+
+def test_post_queues_work_and_returns_202():
+    headers = {
+        "Content-Length": "20",
+        "X-GitHub-Event": "issues",
+        "X-GitHub-Delivery": "abc-123",
+    }
+    body = b'{"action":"opened"}'
+    handler, server = _make_handler(headers, body)
+
+    handler.do_POST()
+
+    assert getattr(handler, "_response_code", None) == 202
+    raw = handler.wfile.getvalue()
+    assert b"Accepted" in raw
+    assert b"work 1" in raw
+    assert b"abc-123" in raw
+    server.hookshot_executor.submit.assert_called_once()
+    args, kwargs = server.hookshot_executor.submit.call_args
+    assert args[0] is _run_webhook_commands
+    assert args[2] == 1  # work_id
+    assert args[3] == "abc-123"  # delivery
+
+
+@patch("hookshot.server.match_and_run", return_value=2)
+def test_run_webhook_commands_invokes_matcher(mock_match):
+    server = MagicMock()
+    server.hookshot_state = MagicMock()
+    _run_webhook_commands(
+        server,
+        7,
+        "del-1",
+        "issues",
+        {"action": "opened"},
+        {"issues": [{"command": "echo"}]},
+        None,
+        None,
+        300,
+    )
+    mock_match.assert_called_once()
+    call = mock_match.call_args
+    assert call[0][0] == {"issues": [{"command": "echo"}]}
+    assert call[0][1] == "issues"
+    assert call[0][2] == {"action": "opened"}
+    assert call[1]["state"] is server.hookshot_state
+    assert call[1]["default_timeout"] == 300
+
+
+@patch("hookshot.server.match_and_run", side_effect=RuntimeError("boom"))
+def test_run_webhook_commands_swallows_and_logs(mock_match, caplog):
+    import logging
+
+    caplog.set_level(logging.ERROR)
+    server = MagicMock()
+    server.hookshot_state = MagicMock()
+    _run_webhook_commands(
+        server,
+        1,
+        "d",
+        "push",
+        {},
+        {},
+        None,
+        None,
+        None,
+    )
+    assert "boom" in caplog.text
+
+
+def test_hookshot_server_has_executor():
+    # bind_and_activate=False avoids binding a real port in tests
+    srv = HookshotHTTPServer(
+        ("127.0.0.1", 0),
+        WebhookHandler,
+        bind_and_activate=False,
+    )
+    assert srv.hookshot_executor is not None
+    assert next(srv.hookshot_work_seq) == 1
+    assert next(srv.hookshot_work_seq) == 2
+    srv.hookshot_executor.shutdown(wait=False)


### PR DESCRIPTION
Closes #17

## Summary

Webhook POST handling now enqueues hook execution on a `ThreadPoolExecutor` (default 8 workers) and returns **202 Accepted** immediately with a short body that includes a monotonic work id and `X-GitHub-Delivery`. Long-running commands no longer block the single-threaded `HTTPServer` accept loop, so concurrent deliveries are processed. Workers log start/finish with work id, delivery id, event name, and thread name (`hookshot-{id}`). Shutdown calls `executor.shutdown(wait=True)` so in-flight work can finish.

## Verification

Run `pytest` (includes new `tests/test_server.py`). Manual: start `hookshot serve`, trigger two webhooks quickly — both should get 202 without waiting for the first command to finish.

Made with [Cursor](https://cursor.com)