### PR TITLE
Fix #30: prevent state log context overflow

### DIFF
--- a/hookshot.yml
+++ b/hookshot.yml
@@ -38,7 +38,7 @@ hooks:
           title: "${{ issue.title }}"
           author: "${{ sender.login }}"
           number: "${{ issue.number }}"
-        log: "Issue #${{ issue.number }} opened by ${{ sender.login }}: ${{ issue.title }}\n\n${{ issue.body }}"
+        log: "Issue #${{ issue.number }} opened by ${{ sender.login }}: ${{ issue.title }} — fetch full body with: gh issue view ${{ issue.number }} --repo ${{ repository.full_name }}"
 
   issue_comment.created:
     # @implement — create a branch, implement, open PR
@@ -75,7 +75,7 @@ hooks:
         key: "issue:${{ repository.full_name }}:${{ issue.number }}"
       store:
         key: "issue:${{ repository.full_name }}:${{ issue.number }}"
-        log: "${{ sender.login }} requested implementation — branch issue-${{ state.number }}"
+        log: "${{ sender.login }} requested implementation (comment ${{ comment.id }}) — branch issue-${{ state.number }}"
 
     # @review on a PR — trigger adversarial reviewer
     - command: "claude -p --dangerously-skip-permissions --model opus"
@@ -128,7 +128,7 @@ hooks:
         key: "pr:${{ repository.full_name }}:${{ issue.number }}"
       store:
         key: "pr:${{ repository.full_name }}:${{ issue.number }}"
-        log: "${{ sender.login }} requested review: ${{ comment.body }}"
+        log: "${{ sender.login }} requested review on PR #${{ issue.number }} (comment ${{ comment.id }}) — fetch with: gh api repos/${{ repository.full_name }}/issues/comments/${{ comment.id }}"
 
     # Human comment on a PR — implementer addresses feedback
     - command: "claude -p --dangerously-skip-permissions --model sonnet"
@@ -167,7 +167,7 @@ hooks:
         key: "pr:${{ repository.full_name }}:${{ issue.number }}"
       store:
         key: "pr:${{ repository.full_name }}:${{ issue.number }}"
-        log: "${{ sender.login }} commented on PR: ${{ comment.body }}"
+        log: "${{ sender.login }} commented on PR #${{ issue.number }} (comment ${{ comment.id }}) — fetch with: gh api repos/${{ repository.full_name }}/issues/comments/${{ comment.id }}"
 
     # Any other human comment on an issue — continue the conversation
     - command: "claude -p --dangerously-skip-permissions --model sonnet"
@@ -199,7 +199,7 @@ hooks:
         key: "issue:${{ repository.full_name }}:${{ issue.number }}"
       store:
         key: "issue:${{ repository.full_name }}:${{ issue.number }}"
-        log: "${{ sender.login }} commented: ${{ comment.body }}"
+        log: "${{ sender.login }} commented on issue #${{ issue.number }} (comment ${{ comment.id }}) — fetch with: gh api repos/${{ repository.full_name }}/issues/comments/${{ comment.id }}"
 
   pull_request.opened, pull_request.reopened:
     - command: "claude -p --dangerously-skip-permissions --model opus"
@@ -296,7 +296,7 @@ hooks:
         key: "pr:${{ repository.full_name }}:${{ pull_request.number }}"
       store:
         key: "pr:${{ repository.full_name }}:${{ pull_request.number }}"
-        log: "Reviewer feedback: ${{ review.body }}"
+        log: "Reviewer ${{ review.user.login }} posted feedback on PR #${{ pull_request.number }} (review ${{ review.id }}) — fetch with: gh api repos/${{ repository.full_name }}/pulls/${{ pull_request.number }}/reviews/${{ review.id }}"
 
     # Reviewer does a follow-up review after implementer responds
     - command: "claude -p --dangerously-skip-permissions --model opus"
@@ -334,7 +334,7 @@ hooks:
         key: "pr:${{ repository.full_name }}:${{ pull_request.number }}"
       store:
         key: "pr:${{ repository.full_name }}:${{ pull_request.number }}"
-        log: "Implementer response: ${{ review.body }}"
+        log: "Implementer ${{ review.user.login }} responded on PR #${{ pull_request.number }} (review ${{ review.id }}) — fetch with: gh api repos/${{ repository.full_name }}/pulls/${{ pull_request.number }}/reviews/${{ review.id }}"
 
   pull_request.closed:
     - command: "echo 'PR #${{ pull_request.number }} closed, cleaning up state'"

--- a/src/hookshot/state.py
+++ b/src/hookshot/state.py
@@ -10,6 +10,9 @@ from pathlib import Path
 
 log = logging.getLogger("hookshot")
 
+MAX_LOG_ENTRY_LENGTH = 500
+MAX_CONTEXT_LENGTH = 4000
+
 
 class StateStore:
     """Flat key-value store where each key holds a bucket of values and a log."""
@@ -75,7 +78,21 @@ class StateStore:
         """
         bucket = self.get(key)
         ctx = dict(bucket.get("values", {}))
-        ctx["context"] = "\n".join(bucket.get("log", []))
+        entries = bucket.get("log", [])
+        joined = "\n".join(entries)
+        if len(joined) > MAX_CONTEXT_LENGTH:
+            # Keep newest entries that fit within the budget
+            kept: list[str] = []
+            total = 0
+            for entry in reversed(entries):
+                needed = len(entry) + (1 if kept else 0)  # +1 for newline separator
+                if total + needed > MAX_CONTEXT_LENGTH:
+                    break
+                kept.append(entry)
+                total += needed
+            kept.reverse()
+            joined = "\n".join(kept)
+        ctx["context"] = joined
         return ctx
 
     def store(self, key: str, values: dict | None = None, log_entry: str | None = None):
@@ -89,6 +106,8 @@ class StateStore:
             if values:
                 bucket["values"].update(values)
             if log_entry:
+                if len(log_entry) > MAX_LOG_ENTRY_LENGTH:
+                    log_entry = log_entry[:MAX_LOG_ENTRY_LENGTH] + "…"
                 bucket["log"].append(log_entry)
             self._save(data)
             log.info("  State stored: %s", key)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,6 +1,6 @@
 """Tests for the state store."""
 
-from hookshot.state import StateStore
+from hookshot.state import MAX_CONTEXT_LENGTH, MAX_LOG_ENTRY_LENGTH, StateStore
 
 
 def test_load_returns_empty_on_corrupt_json(tmp_path):
@@ -75,3 +75,40 @@ def test_store_survives_corrupt_then_writes(tmp_path):
     store2 = StateStore(state_file)
     bucket = store2.get("k1")
     assert bucket["values"]["a"] == "1"
+
+
+def test_store_truncates_long_log_entry(tmp_path):
+    state_file = tmp_path / "state.json"
+    store = StateStore(state_file)
+
+    long_entry = "x" * (MAX_LOG_ENTRY_LENGTH + 100)
+    store.store("k1", log_entry=long_entry)
+    bucket = store.get("k1")
+    assert len(bucket["log"][0]) == MAX_LOG_ENTRY_LENGTH + 1  # +1 for "…"
+    assert bucket["log"][0].endswith("…")
+
+
+def test_get_context_truncates_to_max_length(tmp_path):
+    state_file = tmp_path / "state.json"
+    store = StateStore(state_file)
+
+    # Store many entries that together exceed MAX_CONTEXT_LENGTH
+    for i in range(100):
+        store.store("k1", log_entry=f"entry-{i}: " + "a" * 100)
+
+    ctx = store.get_context("k1")
+    assert len(ctx["context"]) <= MAX_CONTEXT_LENGTH
+
+
+def test_get_context_keeps_newest_entries(tmp_path):
+    state_file = tmp_path / "state.json"
+    store = StateStore(state_file)
+
+    # Store entries where total exceeds limit
+    for i in range(100):
+        store.store("k1", log_entry=f"entry-{i}: " + "a" * 100)
+
+    ctx = store.get_context("k1")
+    # The newest entries should be present, oldest dropped
+    assert "entry-99" in ctx["context"]
+    assert "entry-0" not in ctx["context"]


### PR DESCRIPTION
## Summary
- Rewrote all log entries in `hookshot.yml` to store pointer-style summaries with comment/review IDs instead of embedding full bodies (e.g., `${{ comment.body }}`, `${{ review.body }}`)
- Added `MAX_LOG_ENTRY_LENGTH` (500 chars) truncation in `StateStore.store()` — entries exceeding the limit are truncated with `…`
- Added `MAX_CONTEXT_LENGTH` (4000 chars) truncation in `StateStore.get_context()` — keeps newest log entries that fit within budget, drops oldest
- Added 3 tests covering truncation behavior

## Test plan
- [x] All 134 tests pass
- [x] `test_store_truncates_long_log_entry` — verifies entries are truncated on write
- [x] `test_get_context_truncates_to_max_length` — verifies context stays within budget
- [x] `test_get_context_keeps_newest_entries` — verifies newest entries are preserved

Resolves #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)