### PR TITLE
Fix #29: break review loop with hookshot:approved marker

### DIFF
--- a/hookshot.yml
+++ b/hookshot.yml
@@ -111,11 +111,15 @@ hooks:
              Missing or inadequate test coverage is a blocking issue, not a nice-to-have.
              Run the test suite (uv run pytest) and report the results.
            - Anything the author clearly forgot
-        6. Post your review as a PR review comment. You MUST include the marker
-           <!-- hookshot:reviewer --> at the end of your review body:
-           gh pr review ${{ issue.number }} --repo ${{ repository.full_name }} --body '<your review>
+        6. Post your review:
+           - If the PR needs changes, post with the reviewer marker:
+             gh pr review ${{ issue.number }} --repo ${{ repository.full_name }} --body '<your review>
 
-           <!-- hookshot:reviewer -->' --comment
+             <!-- hookshot:reviewer -->' --comment
+           - If the PR is already good and needs no changes, approve with the approval marker:
+             gh pr review ${{ issue.number }} --repo ${{ repository.full_name }} --approve --body '<your review>
+
+             <!-- hookshot:approved -->'
 
         Be direct. No praise sandwiches. If something is fine, skip it.
         Focus on what's wrong or risky.
@@ -231,11 +235,15 @@ hooks:
              Missing or inadequate test coverage is a blocking issue, not a nice-to-have.
              Run the test suite (uv run pytest) and report the results.
            - Anything the author clearly forgot
-        6. Post your review as a PR review comment. You MUST include the marker
-           <!-- hookshot:reviewer --> at the end of your review body:
-           gh pr review ${{ pull_request.number }} --repo ${{ repository.full_name }} --body '<your review>
+        6. Post your review:
+           - If the PR needs changes, post with the reviewer marker:
+             gh pr review ${{ pull_request.number }} --repo ${{ repository.full_name }} --body '<your review>
 
-           <!-- hookshot:reviewer -->' --comment
+             <!-- hookshot:reviewer -->' --comment
+           - If the PR is already good and needs no changes, approve with the approval marker:
+             gh pr review ${{ pull_request.number }} --repo ${{ repository.full_name }} --approve --body '<your review>
+
+             <!-- hookshot:approved -->'
 
         Be direct. No praise sandwiches. If something is fine, skip it.
         Focus on what's wrong or risky.
@@ -292,6 +300,7 @@ hooks:
            <!-- hookshot:implementer -->' --comment
       if:
         - "${{ review.body | contains hookshot:reviewer }}"
+        - "${{ review.body | not_contains hookshot:approved }}"
       load:
         key: "pr:${{ repository.full_name }}:${{ pull_request.number }}"
       store:
@@ -320,8 +329,10 @@ hooks:
         2. Check each point from your original review — was it actually fixed?
         3. Look for any new issues introduced by the fixes
         4. Run the test suite (uv run pytest) and verify all tests pass
-        5. If everything looks good and tests pass, approve the PR:
-           gh pr review ${{ pull_request.number }} --repo ${{ repository.full_name }} --approve --body '<your response>'
+        5. If everything looks good and tests pass, approve the PR with the approval marker:
+           gh pr review ${{ pull_request.number }} --repo ${{ repository.full_name }} --approve --body '<your response>
+
+           <!-- hookshot:approved -->'
         6. If there are still issues or tests fail, post another review with the marker:
            gh pr review ${{ pull_request.number }} --repo ${{ repository.full_name }} --body '<your response>
 
@@ -330,6 +341,7 @@ hooks:
         Be honest. If it's fixed, say so and approve. If not, be specific about what's still wrong.
       if:
         - "${{ review.body | contains hookshot:implementer }}"
+        - "${{ review.body | not_contains hookshot:approved }}"
       load:
         key: "pr:${{ repository.full_name }}:${{ pull_request.number }}"
       store:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -237,3 +237,36 @@ def test_expand_template_list_with_string_filter():
     payload = {"items": [{"x": "hello"}, {"x": "world"}]}
     result = expand_template("${{ items.*.x | contains hello }}", payload)
     assert result == "true"
+
+
+# --- Review loop termination (issue #29) ---
+
+
+def test_approved_marker_blocks_implementer():
+    """Review body with both hookshot:reviewer and hookshot:approved should not trigger implementer."""
+    body = "Looks good!\n\n<!-- hookshot:reviewer -->\n<!-- hookshot:approved -->"
+    # Implementer fires on: contains hookshot:reviewer AND not_contains hookshot:approved
+    assert apply_filter(body, "contains hookshot:reviewer") == "true"
+    assert apply_filter(body, "not_contains hookshot:approved") == "false"  # blocked
+
+
+def test_approved_marker_blocks_followup_reviewer():
+    """Review body with both hookshot:implementer and hookshot:approved should not trigger reviewer."""
+    body = "All fixed!\n\n<!-- hookshot:implementer -->\n<!-- hookshot:approved -->"
+    # Follow-up reviewer fires on: contains hookshot:implementer AND not_contains hookshot:approved
+    assert apply_filter(body, "contains hookshot:implementer") == "true"
+    assert apply_filter(body, "not_contains hookshot:approved") == "false"  # blocked
+
+
+def test_reviewer_marker_without_approved_triggers_implementer():
+    """Normal review (no approval) should still trigger the implementer."""
+    body = "Fix these bugs.\n\n<!-- hookshot:reviewer -->"
+    assert apply_filter(body, "contains hookshot:reviewer") == "true"
+    assert apply_filter(body, "not_contains hookshot:approved") == "true"  # passes
+
+
+def test_implementer_marker_without_approved_triggers_reviewer():
+    """Normal implementer response should still trigger follow-up reviewer."""
+    body = "Fixed everything.\n\n<!-- hookshot:implementer -->"
+    assert apply_filter(body, "contains hookshot:implementer") == "true"
+    assert apply_filter(body, "not_contains hookshot:approved") == "true"  # passes


### PR DESCRIPTION
## Summary
- Added `not_contains hookshot:approved` guard to both the implementer hook and follow-up reviewer hook, so approvals terminate the review cycle
- Updated all reviewer prompts (@review trigger, PR opened, follow-up reviewer) to use `<!-- hookshot:approved -->` marker when approving and `<!-- hookshot:reviewer -->` when requesting changes
- Added 4 tests verifying the marker logic correctly blocks/allows hook triggering

## Test plan
- [x] All 135 tests pass
- [x] `test_approved_marker_blocks_implementer` — body with both reviewer+approved markers blocks implementer
- [x] `test_approved_marker_blocks_followup_reviewer` — body with both implementer+approved markers blocks reviewer
- [x] `test_reviewer_marker_without_approved_triggers_implementer` — normal review still triggers implementer
- [x] `test_implementer_marker_without_approved_triggers_reviewer` — normal response still triggers reviewer

Resolves #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)