### PR TITLE
Fix #34: hookshot init --workflow for starter templates

### DIFF
--- a/src/hookshot/__main__.py
+++ b/src/hookshot/__main__.py
@@ -7,12 +7,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-import yaml
-
 from .config import LOCAL_CONFIG_PATH, get_events, load_config, validate_config
 from .matcher import match_and_run
 from .server import serve
 from .state import StateStore
+from .templates import AVAILABLE_WORKFLOWS, generate_template
 
 
 class _HookshotFileFormatter(logging.Formatter):
@@ -72,7 +71,18 @@ def main():
     )
 
     # init
-    sub.add_parser("init", help="Create a starter hookshot.yml config")
+    init_parser = sub.add_parser("init", help="Create a starter hookshot.yml config")
+    init_parser.add_argument(
+        "--workflow", "-w",
+        choices=AVAILABLE_WORKFLOWS,
+        default=None,
+        help="Workflow template (pr-review, issue-triage, full)",
+    )
+    init_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing config file",
+    )
 
     # state
     state_parser = sub.add_parser("state", help="Inspect and manage state")
@@ -137,8 +147,8 @@ def _detect_repo() -> str | None:
 def cmd_init(args):
     config_path = args.config or LOCAL_CONFIG_PATH
 
-    if config_path.exists():
-        print(f"Config already exists: {config_path}", file=sys.stderr)
+    if config_path.exists() and not args.force:
+        print(f"Config already exists: {config_path} (use --force to overwrite)", file=sys.stderr)
         sys.exit(1)
 
     repo = _detect_repo()
@@ -151,24 +161,27 @@ def cmd_init(args):
             print("Aborted.", file=sys.stderr)
             sys.exit(1)
 
-    config = {
-        "repo": repo,
-        "hooks": {
-            "issues.opened": [
-                {"command": "echo 'New issue #${{ issue.number }}: ${{ issue.title }}'"}
-            ],
-            "push": [
-                {"command": "echo 'Push to ${{ repository.full_name }} on ${{ ref }}'"}
-            ],
-        },
-    }
+    workflow = args.workflow
+    if not workflow:
+        print("\nAvailable workflows:")
+        print("  pr-review     — adversarial PR review with reviewer/implementer loop")
+        print("  issue-triage  — issue analysis, conversation, and @implement trigger")
+        print("  full          — combines both workflows (recommended)")
+        print()
+        workflow = input("Choose a workflow [full]: ").strip() or "full"
+        if workflow not in AVAILABLE_WORKFLOWS:
+            print(f"Unknown workflow: {workflow}", file=sys.stderr)
+            sys.exit(1)
+
+    content = generate_template(workflow, repo)
 
     config_path.parent.mkdir(parents=True, exist_ok=True)
     with open(config_path, "w") as f:
-        yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+        f.write(content)
 
-    print(f"Created {config_path}")
-    print("Edit the hooks to match your needs, then run: hookshot serve")
+    print(f"Created {config_path} with '{workflow}' workflow")
+    print("Run: hookshot validate")
+    print("Then: hookshot serve")
 
 
 def cmd_validate(args):

--- a/src/hookshot/templates.py
+++ b/src/hookshot/templates.py
@@ -1,0 +1,571 @@
+"""Starter workflow templates for hookshot init."""
+
+AVAILABLE_WORKFLOWS = ("pr-review", "issue-triage", "full")
+
+# Shared agents used across workflows
+_REVIEWER_AGENT = """\
+  reviewer:
+    command: "claude -p --dangerously-skip-permissions --model opus"
+    stdin: |
+      You are an adversarial code reviewer for the {repo} project.
+      Your job is to find problems, not to be polite.
+
+      Review steps:
+      1. Parse the PR title/body to find the related issue number (look for "Resolves #N" or "Fix #N")
+      2. Fetch the original issue and its comments for full context:
+         gh issue view <N> --repo ${{{{ repository.full_name }}}} --comments
+      3. Fetch the PR diff (use the PR number from context below)
+      4. Read every changed file in full to understand the broader context
+      5. Write a brutal, thorough review covering:
+         - Does the implementation actually solve the issue as described?
+         - Bugs, logic errors, edge cases that will break
+         - Security issues (injection, secrets, permissions)
+         - Missing error handling that matters
+         - Race conditions or concurrency problems
+         - Things that will bite us in 6 months (maintenance traps)
+         - TEST COVERAGE (BLOCKING): Do the tests adequately cover the changes?
+           Are there new code paths without tests? Are edge cases tested?
+           Missing or inadequate test coverage is a blocking issue, not a nice-to-have.
+           Run the test suite and report the results.
+         - Anything the author clearly forgot
+      6. Post your review:
+         - If the PR needs changes, post with the reviewer marker:
+           gh pr review <PR_NUMBER> --repo ${{{{ repository.full_name }}}} --body '<your review>
+
+           <!-- hookshot:reviewer -->' --comment
+         - If the PR is already good and needs no changes, approve with the approval marker:
+           gh pr review <PR_NUMBER> --repo ${{{{ repository.full_name }}}} --approve --body '<your review>
+
+           <!-- hookshot:approved -->'
+
+      Be direct. No praise sandwiches. If something is fine, skip it.
+      Focus on what's wrong or risky.
+"""
+
+_IMPLEMENTER_AGENT = """\
+  implementer:
+    command: "claude -p --dangerously-skip-permissions --model sonnet"
+    stdin: |
+      You are the implementer for a PR on the {repo} project.
+      Your job is to address feedback — fix bugs, improve code, and push new commits.
+      Dismiss anything that's wrong or nitpicky, but explain why.
+
+      Steps:
+      1. Parse the PR body to find the related issue number (look for "Resolves #N")
+      2. Fetch the original issue for context:
+         gh issue view <N> --repo ${{{{ repository.full_name }}}} --comments
+      3. Fetch the current PR diff (use the PR number from context below)
+      4. Check out the PR branch (use the branch from context below)
+      5. Read the reviewed files and address each point from the feedback:
+         - Fix legitimate bugs and issues
+         - Add missing error handling or tests if warranted
+         - For points you disagree with, note why
+      6. Run the full test suite
+         If any tests fail, fix them before pushing. Do NOT push with failing tests.
+      7. Commit and push your changes:
+         git add -A && git commit -m 'address review feedback' && git push
+      8. Post a response as a PR review comment. Include the marker
+         <!-- hookshot:implementer --> at the end:
+         gh pr review <PR_NUMBER> --repo ${{{{ repository.full_name }}}} --body '<your response>
+
+         <!-- hookshot:implementer -->' --comment
+"""
+
+_ANALYST_AGENT = """\
+  analyst:
+    command: "claude -p --dangerously-skip-permissions --model opus"
+    stdin: |
+      You are analyzing a new GitHub issue for the {repo} project.
+      Be concise. Focus on feasibility, affected files, and a clear step-by-step plan.
+      Include a "Testing" section that specifies what tests should be written or updated
+      to cover the proposed changes.
+
+      Post your analysis and plan as a comment on the issue.
+      You MUST include the marker <!-- hookshot:agent --> at the end of your comment:
+      gh issue comment ${{{{ issue.number }}}} --repo ${{{{ repository.full_name }}}} --body '<your analysis>
+
+      <!-- hookshot:agent -->'
+"""
+
+_CONVERSATIONALIST_AGENT = """\
+  conversationalist:
+    command: "claude -p --dangerously-skip-permissions --model sonnet"
+    stdin: |
+      You are discussing a GitHub issue for the {repo} project.
+      Respond thoughtfully. If they ask questions about the plan, clarify.
+      If they suggest changes, update your thinking.
+      If they provide more context, incorporate it.
+
+      Post your response as a comment on the issue.
+      You MUST include the marker <!-- hookshot:agent --> at the end of your comment:
+      gh issue comment ${{{{ state.number }}}} --repo ${{{{ repository.full_name }}}} --body '<your response>
+
+      <!-- hookshot:agent -->'
+"""
+
+
+def _pr_review_template(repo: str) -> str:
+    return f"""\
+repo: {repo}
+
+agents:
+{_REVIEWER_AGENT.format(repo=repo)}
+{_IMPLEMENTER_AGENT.format(repo=repo)}
+
+hooks:
+  # Auto-review when a PR is opened or reopened
+  pull_request.opened, pull_request.reopened:
+    - agent: reviewer
+      stdin: |
+        PR #${{{{ pull_request.number }}}}: ${{{{ pull_request.title }}}}
+        Author: ${{{{ sender.login }}}}
+        Branch: ${{{{ pull_request.head.ref }}}} → ${{{{ pull_request.base.ref }}}}
+        Body: ${{{{ pull_request.body }}}}
+
+        Use PR number ${{{{ pull_request.number }}}} for all gh commands.
+      if:
+        - "${{{{ sender.type | neq Bot }}}}"
+      store:
+        key: "pr:${{{{ repository.full_name }}}}:${{{{ pull_request.number }}}}"
+        values:
+          pr_number: "${{{{ pull_request.number }}}}"
+          pr_title: "${{{{ pull_request.title }}}}"
+          pr_author: "${{{{ sender.login }}}}"
+          pr_branch: "${{{{ pull_request.head.ref }}}}"
+        log: "PR #${{{{ pull_request.number }}}} opened by ${{{{ sender.login }}}}: ${{{{ pull_request.title }}}}"
+
+  issue_comment.created:
+    # @review on a PR — trigger adversarial reviewer
+    - agent: reviewer
+      stdin: |
+        A human has requested a fresh review.
+
+        PR #${{{{ issue.number }}}}: ${{{{ issue.title }}}}
+        Requested by: ${{{{ sender.login }}}}
+        Additional context from their comment:
+        ${{{{ comment.body }}}}
+
+        Prior context:
+        ${{{{ state.context }}}}
+
+        Use PR number ${{{{ issue.number }}}} for all gh commands.
+      if:
+        - "${{{{ sender.type | neq Bot }}}}"
+        - "${{{{ comment.body | not_contains hookshot:agent }}}}"
+        - "${{{{ issue.pull_request.url | neq }}}}"
+        - "${{{{ comment.body | contains @review }}}}"
+      load:
+        key: "pr:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+      store:
+        key: "pr:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+        log: "${{{{ sender.login }}}} requested review on PR #${{{{ issue.number }}}} (comment ${{{{ comment.id }}}})"
+
+    # Human comment on a PR — implementer addresses feedback
+    - agent: implementer
+      stdin: |
+        A human has left feedback on your PR. Address their concerns.
+
+        PR #${{{{ issue.number }}}}: ${{{{ issue.title }}}}
+        Comment from ${{{{ sender.login }}}}:
+        ${{{{ comment.body }}}}
+
+        Prior context:
+        ${{{{ state.context }}}}
+
+        Use PR number ${{{{ issue.number }}}} for all gh commands.
+        Branch: ${{{{ state.pr_branch }}}}
+
+        Reply on the PR explaining what you changed.
+        You MUST include the marker <!-- hookshot:agent --> at the end of your comment:
+        gh pr comment ${{{{ issue.number }}}} --repo ${{{{ repository.full_name }}}} --body '<your response>
+
+        <!-- hookshot:agent -->'
+      if:
+        - "${{{{ sender.type | neq Bot }}}}"
+        - "${{{{ comment.body | not_contains hookshot:agent }}}}"
+        - "${{{{ issue.pull_request.url | neq }}}}"
+        - "${{{{ comment.body | not_contains @review }}}}"
+      load:
+        key: "pr:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+      store:
+        key: "pr:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+        log: "${{{{ sender.login }}}} commented on PR #${{{{ issue.number }}}} (comment ${{{{ comment.id }}}})"
+
+  pull_request_review.submitted, pull_request_review.edited:
+    # Implementer responds to adversarial review
+    - agent: implementer
+      stdin: |
+        An adversarial reviewer has posted feedback on your PR.
+
+        PR #${{{{ pull_request.number }}}}: ${{{{ pull_request.title }}}}
+        Branch: ${{{{ pull_request.head.ref }}}}
+        Body: ${{{{ pull_request.body }}}}
+
+        Review from ${{{{ review.user.login }}}}:
+        ${{{{ review.body }}}}
+
+        Prior context:
+        ${{{{ state.context }}}}
+
+        Use PR number ${{{{ pull_request.number }}}} for all gh commands.
+      if:
+        - "${{{{ review.body | contains hookshot:reviewer }}}}"
+        - "${{{{ review.body | not_contains hookshot:approved }}}}"
+      load:
+        key: "pr:${{{{ repository.full_name }}}}:${{{{ pull_request.number }}}}"
+      store:
+        key: "pr:${{{{ repository.full_name }}}}:${{{{ pull_request.number }}}}"
+        log: "Reviewer ${{{{ review.user.login }}}} posted feedback on PR #${{{{ pull_request.number }}}} (review ${{{{ review.id }}}})"
+
+    # Reviewer does a follow-up review after implementer responds
+    - agent: reviewer
+      stdin: |
+        The implementer has responded to your review and pushed changes.
+        Do a follow-up review — check if your concerns were actually addressed.
+
+        PR #${{{{ pull_request.number }}}}: ${{{{ pull_request.title }}}}
+        Branch: ${{{{ pull_request.head.ref }}}}
+
+        Implementer's response:
+        ${{{{ review.body }}}}
+
+        Prior context:
+        ${{{{ state.context }}}}
+
+        Use PR number ${{{{ pull_request.number }}}} for all gh commands.
+
+        Be honest. If it's fixed, say so and approve. If not, be specific about what's still wrong.
+      if:
+        - "${{{{ review.body | contains hookshot:implementer }}}}"
+        - "${{{{ review.body | not_contains hookshot:approved }}}}"
+      load:
+        key: "pr:${{{{ repository.full_name }}}}:${{{{ pull_request.number }}}}"
+      store:
+        key: "pr:${{{{ repository.full_name }}}}:${{{{ pull_request.number }}}}"
+        log: "Implementer ${{{{ review.user.login }}}} responded on PR #${{{{ pull_request.number }}}} (review ${{{{ review.id }}}})"
+
+  # Clean up state when PR is closed
+  pull_request.closed:
+    - command: "echo 'PR #${{{{ pull_request.number }}}} closed, cleaning up state'"
+      clear:
+        - "pr:${{{{ repository.full_name }}}}:${{{{ pull_request.number }}}}"
+"""
+
+
+def _issue_triage_template(repo: str) -> str:
+    return f"""\
+repo: {repo}
+
+agents:
+{_ANALYST_AGENT.format(repo=repo)}
+{_CONVERSATIONALIST_AGENT.format(repo=repo)}
+
+hooks:
+  # Analyze new issues
+  issues.opened, issues.reopened:
+    - agent: analyst
+      stdin: |
+        Issue #${{{{ issue.number }}}}: ${{{{ issue.title }}}}
+        Author: ${{{{ sender.login }}}}
+        Body: ${{{{ issue.body }}}}
+      store:
+        key: "issue:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+        values:
+          title: "${{{{ issue.title }}}}"
+          author: "${{{{ sender.login }}}}"
+          number: "${{{{ issue.number }}}}"
+        log: "Issue #${{{{ issue.number }}}} opened by ${{{{ sender.login }}}}: ${{{{ issue.title }}}} — fetch full body with: gh issue view ${{{{ issue.number }}}} --repo ${{{{ repository.full_name }}}}"
+
+  issue_comment.created:
+    # @implement — create a branch, implement, open PR
+    - command: "claude -p --dangerously-skip-permissions --model sonnet"
+      stdin: |
+        You are working on a GitHub issue for the {repo} project.
+
+        Context of what has happened so far:
+        ${{{{ state.context }}}}
+
+        The user ${{{{ sender.login }}}} has asked you to implement the plan.
+
+        1. Read the plan from the context above
+        2. Create a new branch: git checkout -b issue-${{{{ state.number }}}}
+        3. Implement the changes
+        4. Write tests for any new or changed functionality
+        5. Run the full test suite. If any tests fail, fix them before proceeding.
+        6. Commit and push the branch
+        7. Open a PR using:
+           gh pr create --title 'Fix #${{{{ state.number }}}}: ${{{{ state.title }}}}' --body 'Resolves #${{{{ state.number }}}}'
+        8. Comment on the issue with a link to the PR.
+           You MUST include the marker <!-- hookshot:agent --> at the end of your comment:
+           gh issue comment ${{{{ state.number }}}} --repo ${{{{ repository.full_name }}}} --body '<your comment with PR link>
+
+           <!-- hookshot:agent -->'
+      if:
+        - "${{{{ sender.type | neq Bot }}}}"
+        - "${{{{ comment.body | not_contains hookshot:agent }}}}"
+        - "${{{{ comment.body | contains @implement }}}}"
+      load:
+        key: "issue:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+      store:
+        key: "issue:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+        log: "${{{{ sender.login }}}} requested implementation (comment ${{{{ comment.id }}}}) — branch issue-${{{{ state.number }}}}"
+
+    # Any other human comment on an issue — continue the conversation
+    - agent: conversationalist
+      stdin: |
+        Context of what has happened so far:
+        ${{{{ state.context }}}}
+
+        A new comment was posted by ${{{{ sender.login }}}}:
+        ${{{{ comment.body }}}}
+      if:
+        - "${{{{ sender.type | neq Bot }}}}"
+        - "${{{{ comment.body | not_contains hookshot:agent }}}}"
+        - "${{{{ comment.body | not_contains hookshot:reviewer }}}}"
+        - "${{{{ comment.body | not_contains @implement }}}}"
+        - "${{{{ issue.pull_request.url | eq }}}}"
+      load:
+        key: "issue:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+      store:
+        key: "issue:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+        log: "${{{{ sender.login }}}} commented on issue #${{{{ issue.number }}}} (comment ${{{{ comment.id }}}})"
+
+  # Clean up state when issue is closed
+  issues.closed:
+    - command: "echo 'Issue #${{{{ issue.number }}}} closed, cleaning up state'"
+      clear:
+        - "issue:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+"""
+
+
+def _full_template(repo: str) -> str:
+    return f"""\
+repo: {repo}
+
+agents:
+{_ANALYST_AGENT.format(repo=repo)}
+{_REVIEWER_AGENT.format(repo=repo)}
+{_IMPLEMENTER_AGENT.format(repo=repo)}
+{_CONVERSATIONALIST_AGENT.format(repo=repo)}
+
+hooks:
+  # Analyze new issues
+  issues.opened, issues.reopened:
+    - agent: analyst
+      stdin: |
+        Issue #${{{{ issue.number }}}}: ${{{{ issue.title }}}}
+        Author: ${{{{ sender.login }}}}
+        Body: ${{{{ issue.body }}}}
+      store:
+        key: "issue:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+        values:
+          title: "${{{{ issue.title }}}}"
+          author: "${{{{ sender.login }}}}"
+          number: "${{{{ issue.number }}}}"
+        log: "Issue #${{{{ issue.number }}}} opened by ${{{{ sender.login }}}}: ${{{{ issue.title }}}} — fetch full body with: gh issue view ${{{{ issue.number }}}} --repo ${{{{ repository.full_name }}}}"
+
+  issue_comment.created:
+    # @implement — create a branch, implement, open PR
+    - command: "claude -p --dangerously-skip-permissions --model sonnet"
+      stdin: |
+        You are working on a GitHub issue for the {repo} project.
+
+        Context of what has happened so far:
+        ${{{{ state.context }}}}
+
+        The user ${{{{ sender.login }}}} has asked you to implement the plan.
+
+        1. Read the plan from the context above
+        2. Create a new branch: git checkout -b issue-${{{{ state.number }}}}
+        3. Implement the changes
+        4. Write tests for any new or changed functionality
+        5. Run the full test suite. If any tests fail, fix them before proceeding.
+        6. Commit and push the branch
+        7. Open a PR using:
+           gh pr create --title 'Fix #${{{{ state.number }}}}: ${{{{ state.title }}}}' --body 'Resolves #${{{{ state.number }}}}'
+        8. Comment on the issue with a link to the PR.
+           You MUST include the marker <!-- hookshot:agent --> at the end of your comment:
+           gh issue comment ${{{{ state.number }}}} --repo ${{{{ repository.full_name }}}} --body '<your comment with PR link>
+
+           <!-- hookshot:agent -->'
+      if:
+        - "${{{{ sender.type | neq Bot }}}}"
+        - "${{{{ comment.body | not_contains hookshot:agent }}}}"
+        - "${{{{ comment.body | contains @implement }}}}"
+      load:
+        key: "issue:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+      store:
+        key: "issue:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+        log: "${{{{ sender.login }}}} requested implementation (comment ${{{{ comment.id }}}}) — branch issue-${{{{ state.number }}}}"
+
+    # @review on a PR — trigger adversarial reviewer
+    - agent: reviewer
+      stdin: |
+        A human has requested a fresh review.
+
+        PR #${{{{ issue.number }}}}: ${{{{ issue.title }}}}
+        Requested by: ${{{{ sender.login }}}}
+        Additional context from their comment:
+        ${{{{ comment.body }}}}
+
+        Prior context:
+        ${{{{ state.context }}}}
+
+        Use PR number ${{{{ issue.number }}}} for all gh commands.
+      if:
+        - "${{{{ sender.type | neq Bot }}}}"
+        - "${{{{ comment.body | not_contains hookshot:agent }}}}"
+        - "${{{{ issue.pull_request.url | neq }}}}"
+        - "${{{{ comment.body | contains @review }}}}"
+      load:
+        key: "pr:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+      store:
+        key: "pr:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+        log: "${{{{ sender.login }}}} requested review on PR #${{{{ issue.number }}}} (comment ${{{{ comment.id }}}})"
+
+    # Human comment on a PR — implementer addresses feedback
+    - agent: implementer
+      stdin: |
+        A human has left feedback on your PR. Address their concerns.
+
+        PR #${{{{ issue.number }}}}: ${{{{ issue.title }}}}
+        Comment from ${{{{ sender.login }}}}:
+        ${{{{ comment.body }}}}
+
+        Prior context:
+        ${{{{ state.context }}}}
+
+        Use PR number ${{{{ issue.number }}}} for all gh commands.
+        Branch: ${{{{ state.pr_branch }}}}
+
+        Reply on the PR explaining what you changed.
+        You MUST include the marker <!-- hookshot:agent --> at the end of your comment:
+        gh pr comment ${{{{ issue.number }}}} --repo ${{{{ repository.full_name }}}} --body '<your response>
+
+        <!-- hookshot:agent -->'
+      if:
+        - "${{{{ sender.type | neq Bot }}}}"
+        - "${{{{ comment.body | not_contains hookshot:agent }}}}"
+        - "${{{{ issue.pull_request.url | neq }}}}"
+        - "${{{{ comment.body | not_contains @review }}}}"
+      load:
+        key: "pr:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+      store:
+        key: "pr:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+        log: "${{{{ sender.login }}}} commented on PR #${{{{ issue.number }}}} (comment ${{{{ comment.id }}}})"
+
+    # Any other human comment on an issue — continue the conversation
+    - agent: conversationalist
+      stdin: |
+        Context of what has happened so far:
+        ${{{{ state.context }}}}
+
+        A new comment was posted by ${{{{ sender.login }}}}:
+        ${{{{ comment.body }}}}
+      if:
+        - "${{{{ sender.type | neq Bot }}}}"
+        - "${{{{ comment.body | not_contains hookshot:agent }}}}"
+        - "${{{{ comment.body | not_contains hookshot:reviewer }}}}"
+        - "${{{{ comment.body | not_contains @implement }}}}"
+        - "${{{{ issue.pull_request.url | eq }}}}"
+      load:
+        key: "issue:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+      store:
+        key: "issue:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+        log: "${{{{ sender.login }}}} commented on issue #${{{{ issue.number }}}} (comment ${{{{ comment.id }}}})"
+
+  # Auto-review when a PR is opened or reopened
+  pull_request.opened, pull_request.reopened:
+    - agent: reviewer
+      stdin: |
+        PR #${{{{ pull_request.number }}}}: ${{{{ pull_request.title }}}}
+        Author: ${{{{ sender.login }}}}
+        Branch: ${{{{ pull_request.head.ref }}}} → ${{{{ pull_request.base.ref }}}}
+        Body: ${{{{ pull_request.body }}}}
+
+        Use PR number ${{{{ pull_request.number }}}} for all gh commands.
+      if:
+        - "${{{{ sender.type | neq Bot }}}}"
+      store:
+        key: "pr:${{{{ repository.full_name }}}}:${{{{ pull_request.number }}}}"
+        values:
+          pr_number: "${{{{ pull_request.number }}}}"
+          pr_title: "${{{{ pull_request.title }}}}"
+          pr_author: "${{{{ sender.login }}}}"
+          pr_branch: "${{{{ pull_request.head.ref }}}}"
+        log: "PR #${{{{ pull_request.number }}}} opened by ${{{{ sender.login }}}}: ${{{{ pull_request.title }}}}"
+
+  pull_request_review.submitted, pull_request_review.edited:
+    # Implementer responds to adversarial review
+    - agent: implementer
+      stdin: |
+        An adversarial reviewer has posted feedback on your PR.
+
+        PR #${{{{ pull_request.number }}}}: ${{{{ pull_request.title }}}}
+        Branch: ${{{{ pull_request.head.ref }}}}
+        Body: ${{{{ pull_request.body }}}}
+
+        Review from ${{{{ review.user.login }}}}:
+        ${{{{ review.body }}}}
+
+        Prior context:
+        ${{{{ state.context }}}}
+
+        Use PR number ${{{{ pull_request.number }}}} for all gh commands.
+      if:
+        - "${{{{ review.body | contains hookshot:reviewer }}}}"
+        - "${{{{ review.body | not_contains hookshot:approved }}}}"
+      load:
+        key: "pr:${{{{ repository.full_name }}}}:${{{{ pull_request.number }}}}"
+      store:
+        key: "pr:${{{{ repository.full_name }}}}:${{{{ pull_request.number }}}}"
+        log: "Reviewer ${{{{ review.user.login }}}} posted feedback on PR #${{{{ pull_request.number }}}} (review ${{{{ review.id }}}})"
+
+    # Reviewer does a follow-up review after implementer responds
+    - agent: reviewer
+      stdin: |
+        The implementer has responded to your review and pushed changes.
+        Do a follow-up review — check if your concerns were actually addressed.
+
+        PR #${{{{ pull_request.number }}}}: ${{{{ pull_request.title }}}}
+        Branch: ${{{{ pull_request.head.ref }}}}
+
+        Implementer's response:
+        ${{{{ review.body }}}}
+
+        Prior context:
+        ${{{{ state.context }}}}
+
+        Use PR number ${{{{ pull_request.number }}}} for all gh commands.
+
+        Be honest. If it's fixed, say so and approve. If not, be specific about what's still wrong.
+      if:
+        - "${{{{ review.body | contains hookshot:implementer }}}}"
+        - "${{{{ review.body | not_contains hookshot:approved }}}}"
+      load:
+        key: "pr:${{{{ repository.full_name }}}}:${{{{ pull_request.number }}}}"
+      store:
+        key: "pr:${{{{ repository.full_name }}}}:${{{{ pull_request.number }}}}"
+        log: "Implementer ${{{{ review.user.login }}}} responded on PR #${{{{ pull_request.number }}}} (review ${{{{ review.id }}}})"
+
+  # Clean up state when PR or issue is closed
+  pull_request.closed:
+    - command: "echo 'PR #${{{{ pull_request.number }}}} closed, cleaning up state'"
+      clear:
+        - "pr:${{{{ repository.full_name }}}}:${{{{ pull_request.number }}}}"
+
+  issues.closed:
+    - command: "echo 'Issue #${{{{ issue.number }}}} closed, cleaning up state'"
+      clear:
+        - "issue:${{{{ repository.full_name }}}}:${{{{ issue.number }}}}"
+"""
+
+
+def generate_template(workflow: str, repo: str) -> str:
+    """Generate a hookshot.yml config from a workflow template."""
+    generators = {
+        "pr-review": _pr_review_template,
+        "issue-triage": _issue_triage_template,
+        "full": _full_template,
+    }
+    return generators[workflow](repo)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,66 @@
+"""Tests for workflow templates."""
+
+import yaml
+
+from hookshot.config import load_config, validate_config
+from hookshot.templates import AVAILABLE_WORKFLOWS, generate_template
+
+
+def test_all_templates_are_valid_yaml():
+    for workflow in AVAILABLE_WORKFLOWS:
+        content = generate_template(workflow, "owner/repo")
+        config = yaml.safe_load(content)
+        assert isinstance(config, dict), f"{workflow}: not a dict"
+        assert config["repo"] == "owner/repo", f"{workflow}: wrong repo"
+        assert "hooks" in config, f"{workflow}: no hooks"
+        assert "agents" in config, f"{workflow}: no agents"
+
+
+def test_all_templates_pass_validation(tmp_path):
+    for workflow in AVAILABLE_WORKFLOWS:
+        content = generate_template(workflow, "owner/repo")
+        config_path = tmp_path / f"{workflow}.yml"
+        config_path.write_text(content)
+        config = load_config(config_path)
+        errors = validate_config(config)
+        assert not errors, f"{workflow} validation failed: {errors}"
+
+
+def test_pr_review_has_expected_hooks():
+    content = generate_template("pr-review", "owner/repo")
+    config = yaml.safe_load(content)
+    hook_keys = list(config["hooks"].keys())
+    assert "pull_request.opened, pull_request.reopened" in hook_keys
+    assert "issue_comment.created" in hook_keys
+    assert "pull_request_review.submitted, pull_request_review.edited" in hook_keys
+    assert "pull_request.closed" in hook_keys
+
+
+def test_issue_triage_has_expected_hooks():
+    content = generate_template("issue-triage", "owner/repo")
+    config = yaml.safe_load(content)
+    hook_keys = list(config["hooks"].keys())
+    assert "issues.opened, issues.reopened" in hook_keys
+    assert "issue_comment.created" in hook_keys
+    assert "issues.closed" in hook_keys
+
+
+def test_full_has_all_hooks():
+    content = generate_template("full", "owner/repo")
+    config = yaml.safe_load(content)
+    hook_keys = list(config["hooks"].keys())
+    assert "issues.opened, issues.reopened" in hook_keys
+    assert "pull_request.opened, pull_request.reopened" in hook_keys
+    assert "pull_request_review.submitted, pull_request_review.edited" in hook_keys
+    assert "pull_request.closed" in hook_keys
+    assert "issues.closed" in hook_keys
+
+
+def test_templates_preserve_template_expressions():
+    """Ensure ${{ ... }} expressions survive the Python string formatting."""
+    content = generate_template("pr-review", "owner/repo")
+    assert "${{ pull_request.number }}" in content
+    assert "${{ sender.login }}" in content
+    assert "${{ review.body }}" in content
+    assert "hookshot:reviewer" in content
+    assert "hookshot:approved" in content


### PR DESCRIPTION
## Summary
- Added 3 workflow templates: `pr-review`, `issue-triage`, `full` — each generates a complete, working `hookshot.yml` with all markers, guards, state management, and loop termination pre-configured
- Updated `hookshot init` to support `--workflow` flag and interactive selection
- Added `--force` flag to overwrite existing config
- Templates use the `agents:` abstraction from #33
- New user experience: `hookshot init --workflow full` → working config in seconds

## Test plan
- [x] All 156 tests pass
- [x] `test_all_templates_are_valid_yaml` — all 3 templates parse as valid YAML
- [x] `test_all_templates_pass_validation` — all 3 templates pass `validate_config()`
- [x] `test_pr_review_has_expected_hooks` — PR review workflow has correct hook keys
- [x] `test_issue_triage_has_expected_hooks` — issue triage workflow has correct hook keys
- [x] `test_full_has_all_hooks` — full workflow has all hook keys
- [x] `test_templates_preserve_template_expressions` — `${{ ... }}` expressions survive formatting

Resolves #34
Depends on #33 (agents abstraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)