### PR TITLE
docs: update for agents, init --workflow, state limits, and review markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Full documentation uses a **Diátaxis** layout (tutorials, how-to guides, refere
 
 **[docs/README.md](docs/README.md)**
 
-Quick path: [Getting started](docs/tutorials/getting-started.md) → `hookshot init` → `hookshot serve` → `hookshot test`.
+Quick path: [Getting started](docs/tutorials/getting-started.md) → `hookshot init --workflow full` → `hookshot serve` → `hookshot test`.
 
 ## Repository layout
 
-- **[hookshot.yml](hookshot.yml)** — example configuration for this project (agents workflow via explicit `command` / `stdin` entries — there is no top-level **`agents`** indirection in Hookshot today).
+- **[hookshot.yml](hookshot.yml)** — example configuration for this project using the `agents` abstraction for reusable command/prompt definitions.
 - **[docs/](docs/)** — user-facing documentation tree.

--- a/docs/how-to/gate-on-markers.md
+++ b/docs/how-to/gate-on-markers.md
@@ -25,6 +25,30 @@ hooks:
 
 After template expansion, Hookshot treats these strings as truthy/falsy. Rules: [Templates and filters](../reference/templates-and-filters.md#truthiness-for-if).
 
+## Breaking review loops
+
+The generated workflow templates use HTML comment markers to coordinate multi-agent feedback loops. Four markers are conventional:
+
+| Marker | Purpose |
+|--------|---------|
+| `<!-- hookshot:agent -->` | Generic bot marker — all agent comments include this to prevent self-triggering. |
+| `<!-- hookshot:reviewer -->` | Identifies a review submitted by the reviewer agent. |
+| `<!-- hookshot:implementer -->` | Identifies a comment from the implementer agent. |
+| `<!-- hookshot:approved -->` | Signals approval — breaks the reviewer/implementer loop. |
+
+**Example: reviewer triggers implementer, but not after approval**
+
+```yaml
+hooks:
+  pull_request_review.submitted:
+    - agent: implementer
+      if:
+        - "${{ review.body | contains hookshot:reviewer }}"
+        - "${{ review.body | not_contains hookshot:approved }}"
+```
+
+The reviewer includes `<!-- hookshot:approved -->` when satisfied, which causes the `not_contains` condition to fail, stopping the loop.
+
 ## Common patterns
 
 | Intent | Sketch |
@@ -33,6 +57,7 @@ After template expansion, Hookshot treats these strings as truthy/falsy. Rules: 
 | Keyword gate | `contains @deploy` |
 | Avoid feedback loops | `not_contains hookshot:agent` (or your project marker) |
 | Bot-only path | `eq Bot` on `sender.type` |
+| Break review loop on approval | `not_contains hookshot:approved` |
 
 ## See also
 

--- a/docs/how-to/run-agent-from-hook.md
+++ b/docs/how-to/run-agent-from-hook.md
@@ -21,6 +21,32 @@ hooks:
 
 Template rules: [Templates and filters](../reference/templates-and-filters.md).
 
+## Reusable agents
+
+When multiple hooks share the same command and base prompt, define an `agents` block to avoid repetition:
+
+```yaml
+agents:
+  reviewer:
+    command: "claude -p --model opus"
+    stdin: |
+      You are a code reviewer. Be thorough and constructive.
+
+hooks:
+  pull_request.opened:
+    - agent: reviewer
+      stdin: |
+        Review PR #${{ pull_request.number }}: ${{ pull_request.title }}
+  pull_request.synchronize:
+    - agent: reviewer
+      stdin: |
+        Re-review PR #${{ pull_request.number }} after new commits.
+```
+
+The agent's base `stdin` is prepended to each hook's `stdin`. The agent's `command` is used automatically. See [Configuration: Agents](../reference/configuration.md#agents) for the full reference.
+
+To generate a complete config with predefined agents, run `hookshot init --workflow` — see [CLI: init](../reference/cli.md#init).
+
 ## Practical tips
 
 - **Idempotency:** If the agent posts back to GitHub, use a marker comment (HTML or unique string) and an `if` condition with `not_contains` so you do not loop. See [Gate hooks on markers](gate-on-markers.md).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -18,10 +18,31 @@ hookshot [-h] [-c PATH] [-v] <command> ...
 | `serve` | Load config, validate, start HTTP server (`hookshot.server.serve`). |
 | `validate` | Load config, print errors or summary of hooks/events. |
 | `test EVENT PAYLOAD` | Dry-run: expand templates, evaluate `if`, print what would run. `PAYLOAD` is JSON or `@file.json`. |
-| `init` | Create starter `./hookshot.yml` (fails if file exists). |
+| `init` | Create `./hookshot.yml` from a workflow template. See [init details](#init) below. |
 | `state list` | List state keys with value/log counts. |
 | `state get KEY` | Print values and log for one key. |
 | `state clear PATTERN` | Delete key or prefix when pattern ends with `*`. |
+
+### `init`
+
+```text
+hookshot init [--workflow WORKFLOW] [--force]
+```
+
+| Option | Meaning |
+|--------|---------|
+| `--workflow`, `-w` | Workflow template to use: `pr-review`, `issue-triage`, or `full`. If omitted, an interactive menu is shown. |
+| `--force` | Overwrite an existing config file (default: refuse if file exists). |
+
+**Workflows:**
+
+| Workflow | Description |
+|----------|-------------|
+| `pr-review` | Adversarial PR review with reviewer/implementer feedback loop. |
+| `issue-triage` | Issue analysis, conversation, and `@implement` trigger handling. |
+| `full` | Combines both workflows (recommended). |
+
+Hookshot attempts to detect `owner/repo` via `gh repo view`; if that fails, it prompts for manual input. The generated config includes agent definitions, hook entries, and conditional logic ready to customize.
 
 ### `test` event argument
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -14,24 +14,54 @@ Exhaustive description of supported top-level and per-hook keys as implemented i
 | `timeout` | int | Global default command timeout (seconds). Must be positive integer if set. Per-hook overrides. |
 | `worktrees` | mapping | Optional; see [Worktrees](worktrees.md). |
 | `reactions` | mapping | Optional; see [Reactions](reactions.md). |
-
-### Removed / not implemented
-
-- **`agents`**: Older docs described reusable `agents:` blocks. The current codebase does **not** implement agent indirection; each hook entry must include a **`command`** string. YAML anchors or external templating can deduplicate config.
-
-There is **no** `stream` key in the current implementation: command output is captured in full when the process finishes (buffered `stdout`/`stderr`).
+| `agents` | mapping | Optional; reusable agent definitions. Each key is an agent name mapping to `command` (required) and `stdin` (optional base prompt). Hooks reference agents with `agent: <name>`. See [Agents](#agents) below. |
 
 ## Per-hook keys
 
 | Key | Required | Description |
 |-----|----------|-------------|
-| `command` | yes | Shell command after template expansion. |
-| `stdin` | no | String (often multiline) template; passed as stdin to the process. |
+| `command` | yes (unless `agent` used) | Shell command after template expansion. |
+| `agent` | no | Name of a defined agent. Mutually exclusive with `command`. Copies the agent's `command` and prepends the agent's base `stdin` to any hook-level `stdin`. |
+| `stdin` | no | String (often multiline) template; passed as stdin to the process. When used with `agent`, appended to the agent's base `stdin`. |
 | `if` | no | String or list of strings; all must be truthy after expansion. |
 | `timeout` | no | Seconds; overrides global `timeout` for this hook only. |
 | `load` | no | `{ key: "<template>" }`; loads state before expansion; enables worktree cwd when `worktrees` configured. |
 | `store` | no | `{ key, values?, log? }`; runs after successful exit `0`. |
+| `stream` | no | Boolean; when `true`, command output is logged line-by-line as it arrives instead of buffered until exit. |
 | `clear` | no | List of key templates; prefix `*` supported; runs after success. |
+
+## Agents
+
+Define reusable agent blocks at the top level to avoid duplicating `command` and base `stdin` across hooks.
+
+```yaml
+agents:
+  reviewer:
+    command: "claude -p --model opus"
+    stdin: |
+      You are a code reviewer. Be thorough and constructive.
+
+hooks:
+  pull_request.opened:
+    - agent: reviewer
+      stdin: |
+        Review PR #${{ pull_request.number }}: ${{ pull_request.title }}
+```
+
+When a hook references `agent: reviewer`:
+
+1. The agent's `command` is copied into the hook.
+2. The agent's base `stdin` is **prepended** to any hook-level `stdin` (joined with a newline).
+3. The `agent` key is removed after resolution.
+
+A hook **cannot** have both `agent` and `command` — validation rejects this. Every referenced agent name must exist in the top-level `agents` mapping.
+
+Each agent definition accepts only two keys:
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `command` | yes | Shell command string. |
+| `stdin` | no | Base prompt prepended to hook-level `stdin`. |
 
 ## Environment expansion
 
@@ -39,7 +69,7 @@ Expanded early in `load_config` for: `secret`, `state_file`, `repo`, `worktrees.
 
 ## Validation (`hookshot validate`)
 
-Reports: bad `repo` format; invalid `timeout`; hook lists missing `command`; malformed `store` / `load` / `clear`; unsafe `worktrees.path`; invalid `reactions` keys or emoji names.
+Reports: bad `repo` format; invalid `timeout`; hook lists missing `command`; malformed `store` / `load` / `clear`; unsafe `worktrees.path`; invalid `reactions` keys or emoji names; undefined agent references; hooks with both `agent` and `command`; invalid agent definitions.
 
 ## See also
 

--- a/docs/reference/state.md
+++ b/docs/reference/state.md
@@ -23,6 +23,17 @@ All reads and writes use the same pattern: open a sidecar lock file, `flock(LOCK
 
 Corrupt JSON is renamed to `*.corrupt.<unixtime>` and the store starts empty.
 
+## Size limits
+
+To prevent unbounded growth, state enforces two limits:
+
+| Constant | Value | Effect |
+|----------|-------|--------|
+| `MAX_LOG_ENTRY_LENGTH` | 500 chars | Log entries longer than this are truncated and suffixed with `…`. |
+| `MAX_CONTEXT_LENGTH` | 4000 chars | `state.context` (the joined log exposed to templates) keeps only the **newest** entries that fit within this budget. Older entries are silently dropped. |
+
+Truncation happens at write time (for individual entries) and at read time (for context assembly). Values stored via `store.values` are not subject to these limits.
+
 ## Directives
 
 | Directive | When it runs |

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -35,9 +35,23 @@ In an empty or existing project directory:
 hookshot init
 ```
 
-If `gh repo view` works, Hookshot fills in `repo`; otherwise it prompts for `owner/name`.
+Hookshot detects `owner/repo` via `gh repo view` (or prompts for it), then asks you to choose a workflow template:
 
-**Checkpoint:** `hookshot.yml` exists and contains at least `repo` (if you chose one) and `hooks`.
+| Workflow | What it sets up |
+|----------|-----------------|
+| `pr-review` | Adversarial PR review with reviewer/implementer feedback loop. |
+| `issue-triage` | Issue analysis, conversation, and `@implement` trigger handling. |
+| `full` | Combines both workflows (recommended). |
+
+You can skip the interactive prompt by passing the workflow directly:
+
+```bash
+hookshot init --workflow full
+```
+
+Use `--force` to overwrite an existing config file.
+
+**Checkpoint:** `hookshot.yml` exists and contains `repo`, `agents`, and `hooks` sections.
 
 ## Step 3: Validate
 


### PR DESCRIPTION
Align documentation with features shipped in PRs #29, #30, #33, and #34:
- Fix configuration.md falsely claiming agents are not implemented
- Document init --workflow and --force CLI flags
- Add state size limits (MAX_LOG_ENTRY_LENGTH, MAX_CONTEXT_LENGTH)
- Document review loop markers (hookshot:approved, etc.)
- Add reusable agents section to run-agent-from-hook how-to
- Document stream per-hook key
- Update README to reflect agents abstraction